### PR TITLE
CMakeLists.txt: use CMAKE_INSTALL_FULL_LIBDIR for proper absolute path support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 # (but later on when installing)
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
 
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH


### PR DESCRIPTION
The CMAKE_INSTALL_LIBDIR is not necessarily a relative path (may be an absolute one, e.g. for splitting libraries from dev headers in package managers). Concatenating install prefix and such absolute libdir with "/" would result in an invalid path. The `_FULL_` variables are provided by GNUInstallDirs and are intended to handle this correctly.